### PR TITLE
Default installs to 3.0.28 as 3.0.9 is a 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 - Require Chef Infra Client 14 or later
+- Use the system's native init system to determine what init system to run the service under instead of defaulting to sysv-init
+- Switch Fedora to use RHEL 8 packages from RHEL 7 packages
+- Switch platform checks to platform_family to expand platform support
 - Use the build_essential resource and remove the dependency on the build-essential cookbook
 - Removed the apt-get update before adding the Zabbix apt repository as this is not necessary and allows us to remove the apt dependency
 - Removed the include_recipe 'yum' before setting up the Zabbix yum repo as this is not necessary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@
 
 - Require Chef Infra Client 14 or later
 - Use the build_essential resource and remove the dependency on the build-essential cookbook
-- Removed the apt-get update before adding the Zabbix apt repository as this is not necessary
+- Removed the apt-get update before adding the Zabbix apt repository as this is not necessary and allows us to remove the apt dependency
 - Removed the include_recipe 'yum' before setting up the Zabbix yum repo as this is not necessary
 - Removed dependency on apt and yum cookbooks
 - Enable circleci testing
 - Change testing to dokken
 - Remove ChefSpec matchers file which is no longer necessary with ChefSpec 7.1
 - Use multi-package installs where available to speed up package installation
+- Use platform? and platform_family? helpers
+- Simplify the logic for installation redhat-lsb package in the prebuilt recipe
 
 ## 0.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Use multi-package installs where available to speed up package installation
 - Use platform? and platform_family? helpers
 - Simplify the logic for installation redhat-lsb package in the prebuilt recipe
+- Resolved deprecation warnings in ChefSpec
 
 ## 0.14.0
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ node['zabbix']['agent']['install_method'] = 'skip'
 Version
 
 ```ruby
-node['zabbix']['agent']['version'] # Default 3.0.9
+node['zabbix']['agent']['version'] # Default 3.0.28
 ```
 
 Servers
@@ -145,7 +145,7 @@ node['zabbix']['agent']['conf']['ServerActive'] = ["Your_zabbix_active_server.co
 
 #### Package install
 
-If you do not set any attributes you will get an install of zabbix agent version 3.0.9 with
+If you do not set any attributes you will get an install of zabbix agent version 3.0.28 with
 what should be a working configuration if your DNS has aliases for zabbix.yourdomain.com and
 your hosts search yourdomain.com.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,7 +26,7 @@ else
   default['zabbix']['agent']['scripts'] = '/etc/zabbix/scripts'
 end
 
-default['zabbix']['agent']['version']           = '3.0.9'
+default['zabbix']['agent']['version']           = '3.0.28'
 default['zabbix']['agent']['servers']           = ['zabbix']
 default['zabbix']['agent']['servers_active']    = ['zabbix']
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,7 +14,7 @@ default['zabbix']['agent']['config_file']            = ::File.join(node['zabbix'
 default['zabbix']['agent']['userparams_config_file'] = ::File.join(node['zabbix']['agent']['include_dir'], 'user_params.conf')
 default['zabbix']['agent']['pid_file']               = '/var/run/zabbix/zabbix_agentd.pid'
 
-if node['platform'] == 'windows'
+if platform?('windows')
   default['zabbix']['install_dir']      = node['zabbix']['etc_dir']
   default['zabbix']['log_dir']          = ::File.join(node['zabbix']['etc_dir'], 'log')
   default['zabbix']['agent']['scripts'] = ::File.join(node['zabbix']['etc_dir'], 'scripts')
@@ -31,7 +31,7 @@ default['zabbix']['agent']['servers']           = ['zabbix']
 default['zabbix']['agent']['servers_active']    = ['zabbix']
 
 # primary config options
-if node['platform'] == 'windows'
+if platform?('windows')
   default['zabbix']['agent']['user']         = 'Administrator'
   default['zabbix']['agent']['group']        = 'Administrators'
 else
@@ -49,7 +49,7 @@ default['zabbix']['agent']['user_parameter'] = []
 
 # zabbix_agent.conf file set to documented defaults
 default['zabbix']['agent']['conf']['Alias'] = nil
-unless node['platform'] == 'windows'
+unless platform?('windows')
   default['zabbix']['agent']['conf']['AllowRoot'] = '0'
 end
 default['zabbix']['agent']['conf']['BufferSend']  = '5'
@@ -60,14 +60,14 @@ default['zabbix']['agent']['conf']['EnableRemoteCommands'] = '1'
 default['zabbix']['agent']['conf']['HostMetadata'] = nil
 default['zabbix']['agent']['conf']['Hostname']     = nil # defaults to HostnameItem
 # default['zabbix']['agent']['conf']['HostnameItem'] = nil # set by system.hostname
-unless node['platform'] == 'windows'
+unless platform?('windows')
   default['zabbix']['agent']['conf']['HostnameItem'] = 'system.run[hostname -f]'
 end
 # default['zabbix']['agent']['conf']['Include']  = nil #default
 default['zabbix']['agent']['conf']['Include']      = ::File.join(default['zabbix']['agent']['include_dir'], '*.conf')
 default['zabbix']['agent']['conf']['ListenIP']     = '0.0.0.0'
 default['zabbix']['agent']['conf']['ListenPort']   = '10050'
-unless node['platform'] == 'windows'
+unless platform?('windows')
   default['zabbix']['agent']['conf']['LoadModule']   = nil
 end
 default['zabbix']['agent']['conf']['LogType']      = 'system'
@@ -75,10 +75,10 @@ default['zabbix']['agent']['conf']['LogFile']      = nil
 default['zabbix']['agent']['conf']['LogFileSize']  = '1'
 default['zabbix']['agent']['conf']['LogRemoteCommands']  = '0'
 default['zabbix']['agent']['conf']['MaxLinesPerSecond']  = '100'
-if node['platform'] == 'windows'
+if platform?('windows')
   default['zabbix']['agent']['conf']['PerfCounter'] = nil
 end
-unless node['platform'] == 'windows'
+unless platform?('windows')
   # default['zabbix']['agent']['conf']['PidFile']  = '/tmp/zabbix_agentd.pid'
   default['zabbix']['agent']['conf']['PidFile'] = '/var/run/zabbix/zabbix_agentd.pid'
 end
@@ -90,7 +90,7 @@ default['zabbix']['agent']['conf']['SourceIP']     = nil
 default['zabbix']['agent']['conf']['StartAgents']  = '3'
 default['zabbix']['agent']['conf']['Timeout']      = '3'
 default['zabbix']['agent']['conf']['UnsafeUserParameters'] = '0'
-unless node['platform'] == 'windows'
+unless platform?('windows')
   if node['zabbix']['agent']['version'] =~ /2\.4\..*/
     default['zabbix']['agent']['conf']['User'] = default['zabbix']['agent']['user']
   end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -120,7 +120,7 @@ when 'amazon'
   default['zabbix']['agent']['package']['repo_uri'] = 'http://repo.zabbix.com/zabbix/3.0/rhel/6/$basearch/'
   default['zabbix']['agent']['package']['repo_key'] = 'http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX'
 when 'fedora'
-  default['zabbix']['agent']['package']['repo_uri'] = 'http://repo.zabbix.com/zabbix/3.0/rhel/7/$basearch/'
+  default['zabbix']['agent']['package']['repo_uri'] = 'http://repo.zabbix.com/zabbix/3.0/rhel/8/$basearch/'
   default['zabbix']['agent']['package']['repo_key'] = 'http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX'
 end
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -132,14 +132,12 @@ default['zabbix']['agent']['prebuild_file'] = "zabbix_agents_#{version}.linux2_6
 default['zabbix']['agent']['prebuild_url']  = "#{prebuild_url}#{version}/zabbix_agents_#{version}.linux2_6.#{arch}.tar.gz"
 default['zabbix']['agent']['checksum'] = 'bf2ebb48fbbca66418350f399819966e'
 
-# auto-regestration
+# auto-registration
 default['zabbix']['agent']['groups'] = ['chef-agent']
 
-case node['platform_family']
-when 'rhel', 'debian'
-  default['zabbix']['agent']['init_style'] = 'sysvinit'
-when 'fedora'
-  default['zabbix']['agent']['init_style'] = 'systemd'
-when 'windows'
-  default['zabbix']['agent']['init_style'] = 'windows'
-end
+default['zabbix']['agent']['init_style'] = case node['os']
+                                           when 'windows'
+                                             'windows'
+                                           when 'linux'
+                                             node['init_package'] == 'systemd' ? 'systemd' : 'sysvinit'
+                                           end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -108,11 +108,11 @@ default['zabbix']['agent']['source_url'] = "#{download_url}/#{branch}/#{version}
 default['zabbix']['agent']['tar_file'] = tar
 
 # package install
-case node['platform']
-when 'ubuntu', 'debian'
+case node['platform_family']
+when 'debian'
   default['zabbix']['agent']['package']['repo_uri'] = "http://repo.zabbix.com/zabbix/3.0/#{node['platform']}/"
   default['zabbix']['agent']['package']['repo_key'] = 'http://repo.zabbix.com/zabbix-official-repo.key'
-when 'redhat', 'centos', 'scientific', 'oracle'
+when 'rhel'
   default['zabbix']['agent']['package']['repo_uri'] = 'http://repo.zabbix.com/zabbix/3.0/rhel/$releasever/$basearch/'
   default['zabbix']['agent']['package']['repo_key'] = 'http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX'
 when 'amazon'

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -6,6 +6,7 @@
 #
 # Apache 2.0
 #
+
 include_recipe 'zabbix-agent::install'
 
 # Install configuration

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -12,7 +12,7 @@ include_recipe 'zabbix-agent::install'
 template 'zabbix_agentd.conf' do
   path node['zabbix']['agent']['config_file']
   source 'zabbix_agentd.conf.erb'
-  unless node['platform_family'] == 'windows'
+  unless platform_family?('windows')
     owner 'root'
     group 'root'
     mode '644'
@@ -25,7 +25,7 @@ end
 template 'user_params.conf' do
   path node['zabbix']['agent']['userparams_config_file']
   source 'user_params.conf.erb'
-  unless node['platform_family'] == 'windows'
+  unless platform_family?('windows')
     owner 'root'
     group 'root'
     mode '644'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -6,4 +6,5 @@
 #
 # Apache 2.0
 #
+
 include_recipe 'zabbix-agent::service'

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -8,7 +8,7 @@
 #
 
 # Manage user and group
-if node['platform'] == 'windows'
+if platform?('windows')
   user node['zabbix']['agent']['user'] do
     not_if { node['zabbix']['agent']['user'] == 'Administrator' }
   end
@@ -79,7 +79,7 @@ end
 zabbix_dirs = [
   node['zabbix']['log_dir'],
 ]
-zabbix_dirs << node['zabbix']['run_dir'] unless node['platform'] == 'windows'
+zabbix_dirs << node['zabbix']['run_dir'] unless platform?('windows')
 
 # Create zabbix folders
 zabbix_dirs.each do |dir|

--- a/recipes/install_prebuild.rb
+++ b/recipes/install_prebuild.rb
@@ -6,12 +6,8 @@
 #
 # Apache 2.0
 #
-case node['platform']
-when 'redhat', 'centos', 'scientific', 'amazon', 'fedora'
-  package 'redhat-lsb' do
-    action :install
-  end
-end
+
+package 'redhat-lsb' if platform_family?('rhel', 'fedora', 'amazon')
 
 remote_file "#{Chef::Config[:file_cache_path]}/#{node['zabbix']['agent']['prebuild_file']}" do
   source node['zabbix']['agent']['prebuild_url']

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'zabbix-agent::default' do
   context 'with default settings' do
     cached(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '14.04').converge(described_recipe)
+      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '18.04').converge(described_recipe)
     end
 
     it 'includes zabbix-agent::service to insure the zabbix agent will run' do
@@ -112,7 +112,7 @@ describe 'zabbix-agent::default' do
   end
 
   context 'if installed on Ubuntu it' do
-    cached(:chef_run) { ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '14.04').converge(described_recipe) }
+    cached(:chef_run) { ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '18.04').converge(described_recipe) }
 
     it 'adds the apt repository for zabbix' do
       expect(chef_run).to add_apt_repository('zabbix').with(

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -13,14 +13,14 @@ describe 'zabbix-agent install method tests' do
       expect(chef_prebuild).to include_recipe('zabbix-agent::install_prebuild')
     end
 
-    it "gets the zabbix binary prebuild archive from 'http://www.zabbix.com/downloads/ and puts it  #{Chef::Config[:file_cache_path]}/zabbix_agents_3.0.9.linux2_6.amd64.tar.gz" do
-      expect(chef_prebuild).to create_remote_file("#{Chef::Config[:file_cache_path]}/zabbix_agents_3.0.9.linux2_6.amd64.tar.gz").with(
-        source: 'http://www.zabbix.com/downloads/3.0.9/zabbix_agents_3.0.9.linux2_6.amd64.tar.gz'
+    it "gets the zabbix binary prebuild archive from 'http://www.zabbix.com/downloads/ and puts it  #{Chef::Config[:file_cache_path]}/zabbix_agents_3.0.28.linux2_6.amd64.tar.gz" do
+      expect(chef_prebuild).to create_remote_file("#{Chef::Config[:file_cache_path]}/zabbix_agents_3.0.28.linux2_6.amd64.tar.gz").with(
+        source: 'http://www.zabbix.com/downloads/3.0.28/zabbix_agents_3.0.28.linux2_6.amd64.tar.gz'
       )
     end
 
     it 'notifies the bash install_program when the archive is downloaded' do
-      get_file = chef_prebuild.remote_file("#{Chef::Config[:file_cache_path]}/zabbix_agents_3.0.9.linux2_6.amd64.tar.gz")
+      get_file = chef_prebuild.remote_file("#{Chef::Config[:file_cache_path]}/zabbix_agents_3.0.28.linux2_6.amd64.tar.gz")
       expect(get_file).to notify('bash[install_program]').to(:run).immediately
     end
 
@@ -50,14 +50,14 @@ describe 'zabbix-agent install method tests' do
       expect(chef_source).to include_recipe('zabbix-agent::install_source')
     end
 
-    it "gets the zabbix source archive from http://downloads.sourceforge.net and puts it in #{Chef::Config[:file_cache_path]}/zabbix-3.0.9.tar.gz" do
-      expect(chef_source).to create_remote_file("#{Chef::Config[:file_cache_path]}/zabbix-3.0.9.tar.gz").with(
-        source: 'http://downloads.sourceforge.net/project/zabbix//ZABBIX%20Latest%20Stable/3.0.9/zabbix-3.0.9.tar.gz'
+    it "gets the zabbix source archive from http://downloads.sourceforge.net and puts it in #{Chef::Config[:file_cache_path]}/zabbix-3.0.28.tar.gz" do
+      expect(chef_source).to create_remote_file("#{Chef::Config[:file_cache_path]}/zabbix-3.0.28.tar.gz").with(
+        source: 'http://downloads.sourceforge.net/project/zabbix//ZABBIX%20Latest%20Stable/3.0.28/zabbix-3.0.28.tar.gz'
       )
     end
 
-    it 'the download of the zabbix source archive zabbix-3.0.9.tar.gz notifies the bash install_program' do
-      get_file = chef_source.remote_file("#{Chef::Config[:file_cache_path]}/zabbix-3.0.9.tar.gz")
+    it 'the download of the zabbix source archive zabbix-3.0.28.tar.gz notifies the bash install_program' do
+      get_file = chef_source.remote_file("#{Chef::Config[:file_cache_path]}/zabbix-3.0.28.tar.gz")
       expect(get_file).to notify('bash[install_program]').to(:run).immediately
     end
 
@@ -82,9 +82,9 @@ describe 'zabbix-agent install method tests' do
       expect(chef_source).to install_package(%w(curl-devel openssl-devel redhat-lsb))
     end
 
-    it "gets the zabbix source archive from http://downloads.sourceforge.net and puts it in #{Chef::Config[:file_cache_path]}/zabbix-3.0.9.tar.gz" do
-      expect(chef_source).to create_remote_file("#{Chef::Config[:file_cache_path]}/zabbix-3.0.9.tar.gz").with(
-        source: 'http://downloads.sourceforge.net/project/zabbix//ZABBIX%20Latest%20Stable/3.0.9/zabbix-3.0.9.tar.gz'
+    it "gets the zabbix source archive from http://downloads.sourceforge.net and puts it in #{Chef::Config[:file_cache_path]}/zabbix-3.0.28.tar.gz" do
+      expect(chef_source).to create_remote_file("#{Chef::Config[:file_cache_path]}/zabbix-3.0.28.tar.gz").with(
+        source: 'http://downloads.sourceforge.net/project/zabbix//ZABBIX%20Latest%20Stable/3.0.28/zabbix-3.0.28.tar.gz'
       )
     end
   end

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'zabbix-agent install method tests' do
   context 'with install_method=prebuild it' do
     cached(:chef_prebuild) do
-      ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '14.04') do |node|
+      ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '18.04') do |node|
         node.override['zabbix']['agent']['install_method'] = 'prebuild'
         node.override['zabbix']['agent']['init_style'] = 'sysvinit'
       end.converge('zabbix-agent::default')


### PR DESCRIPTION
Cookstyle fixes
ChefSpec deprecation fixes
Install an available version of Zabbix