### PR TITLE
Use platform? and platform_family? helpers where possible to simplify the codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Change testing to dokken
 - Remove ChefSpec matchers file which is no longer necessary with ChefSpec 7.1
 - Use multi-package installs where available to speed up package installation
+- Use platform? and platform_family? helpers where possible to simplify the codebase
 
 ## 0.14.0
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -25,13 +25,13 @@ def test_changes?
   false
 end
 
-fail 'Please provide a summary of your Pull Request.' if github.pr_body.length < 10
+raise 'Please provide a summary of your Pull Request.' if github.pr_body.length < 10
 
 warn 'This is a big Pull Request.' if git.lines_of_code > 400
 
 # Require a CHANGELOG entry for non-test changes.
 if !git.modified_files.include?('CHANGELOG.md') && code_changes?
-  fail 'Please include a CHANGELOG entry.'
+  raise 'Please include a CHANGELOG entry.'
 end
 
 # A sanity check for tests.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,7 +14,7 @@ default['zabbix']['agent']['config_file']            = ::File.join(node['zabbix'
 default['zabbix']['agent']['userparams_config_file'] = ::File.join(node['zabbix']['agent']['include_dir'], 'user_params.conf')
 default['zabbix']['agent']['pid_file']               = '/var/run/zabbix/zabbix_agentd.pid'
 
-if node['platform'] == 'windows'
+if platform?('windows')
   default['zabbix']['install_dir']      = node['zabbix']['etc_dir']
   default['zabbix']['log_dir']          = ::File.join(node['zabbix']['etc_dir'], 'log')
   default['zabbix']['agent']['scripts'] = ::File.join(node['zabbix']['etc_dir'], 'scripts')
@@ -31,7 +31,7 @@ default['zabbix']['agent']['servers']           = ['zabbix']
 default['zabbix']['agent']['servers_active']    = ['zabbix']
 
 # primary config options
-if node['platform'] == 'windows'
+if platform?('windows')
   default['zabbix']['agent']['user']         = 'Administrator'
   default['zabbix']['agent']['group']        = 'Administrators'
 else
@@ -49,7 +49,7 @@ default['zabbix']['agent']['user_parameter'] = []
 
 # zabbix_agent.conf file set to documented defaults
 default['zabbix']['agent']['conf']['Alias'] = nil
-unless node['platform'] == 'windows'
+unless platform?('windows')
   default['zabbix']['agent']['conf']['AllowRoot'] = '0'
 end
 default['zabbix']['agent']['conf']['BufferSend']  = '5'
@@ -60,14 +60,14 @@ default['zabbix']['agent']['conf']['EnableRemoteCommands'] = '1'
 default['zabbix']['agent']['conf']['HostMetadata'] = nil
 default['zabbix']['agent']['conf']['Hostname']     = nil # defaults to HostnameItem
 # default['zabbix']['agent']['conf']['HostnameItem'] = nil # set by system.hostname
-unless node['platform'] == 'windows'
+unless platform?('windows')
   default['zabbix']['agent']['conf']['HostnameItem'] = 'system.run[hostname -f]'
 end
 # default['zabbix']['agent']['conf']['Include']  = nil #default
 default['zabbix']['agent']['conf']['Include']      = ::File.join(default['zabbix']['agent']['include_dir'], '*.conf')
 default['zabbix']['agent']['conf']['ListenIP']     = '0.0.0.0'
 default['zabbix']['agent']['conf']['ListenPort']   = '10050'
-unless node['platform'] == 'windows'
+unless platform?('windows')
   default['zabbix']['agent']['conf']['LoadModule']   = nil
 end
 default['zabbix']['agent']['conf']['LogType']      = 'system'
@@ -75,10 +75,10 @@ default['zabbix']['agent']['conf']['LogFile']      = nil
 default['zabbix']['agent']['conf']['LogFileSize']  = '1'
 default['zabbix']['agent']['conf']['LogRemoteCommands']  = '0'
 default['zabbix']['agent']['conf']['MaxLinesPerSecond']  = '100'
-if node['platform'] == 'windows'
+if platform?('windows')
   default['zabbix']['agent']['conf']['PerfCounter'] = nil
 end
-unless node['platform'] == 'windows'
+unless platform?('windows')
   # default['zabbix']['agent']['conf']['PidFile']  = '/tmp/zabbix_agentd.pid'
   default['zabbix']['agent']['conf']['PidFile'] = '/var/run/zabbix/zabbix_agentd.pid'
 end
@@ -90,7 +90,7 @@ default['zabbix']['agent']['conf']['SourceIP']     = nil
 default['zabbix']['agent']['conf']['StartAgents']  = '3'
 default['zabbix']['agent']['conf']['Timeout']      = '3'
 default['zabbix']['agent']['conf']['UnsafeUserParameters'] = '0'
-unless node['platform'] == 'windows'
+unless platform?('windows')
   if node['zabbix']['agent']['version'] =~ /2\.4\..*/
     default['zabbix']['agent']['conf']['User'] = default['zabbix']['agent']['user']
   end

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -12,7 +12,7 @@ include_recipe 'zabbix-agent::install'
 template 'zabbix_agentd.conf' do
   path node['zabbix']['agent']['config_file']
   source 'zabbix_agentd.conf.erb'
-  unless node['platform_family'] == 'windows'
+  unless platform_family?('windows')
     owner 'root'
     group 'root'
     mode '644'
@@ -25,7 +25,7 @@ end
 template 'user_params.conf' do
   path node['zabbix']['agent']['userparams_config_file']
   source 'user_params.conf.erb'
-  unless node['platform_family'] == 'windows'
+  unless platform_family?('windows')
     owner 'root'
     group 'root'
     mode '644'

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -8,7 +8,7 @@
 #
 
 # Manage user and group
-if node['platform'] == 'windows'
+if platform?('windows')
   user node['zabbix']['agent']['user'] do
     not_if { node['zabbix']['agent']['user'] == 'Administrator' }
   end
@@ -79,7 +79,7 @@ end
 zabbix_dirs = [
   node['zabbix']['log_dir'],
 ]
-zabbix_dirs << node['zabbix']['run_dir'] unless node['platform'] == 'windows'
+zabbix_dirs << node['zabbix']['run_dir'] unless platform?('windows')
 
 # Create zabbix folders
 zabbix_dirs.each do |dir|


### PR DESCRIPTION
This fixes all our cookstyle warnings

Signed-off-by: Tim Smith <tsmith@chef.io>