### PR TITLE
Fix source & prebuilt installs + bump to 3.0.29

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,0 @@
----
-AllCops:
-  Exclude:
-    - 'Dangerfile'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,14 @@
 ## Unreleased
 
 - Require Chef Infra Client 14 or later
+- Upgrade the default client version to 3.0.29 as 3.0.9 isn't on the Zabbix site anymore
+- Fix prebuilt installs since the packages on the Zabbix site have changed name format
+- Use the Linux 3.x prebuilt binaries not 2.6 binaries
 - Use the build_essential resource and remove the dependency on the build-essential cookbook
 - Removed the apt-get update before adding the Zabbix apt repository as this is not necessary
 - Removed the include_recipe 'yum' before setting up the Zabbix yum repo as this is not necessary
 - Removed dependency on apt and yum cookbooks
-- Enable circleci testing
-- Change testing to dokken
+- Change Test Kitchen testing to kitchen-dokken
 - Remove ChefSpec matchers file which is no longer necessary with ChefSpec 7.1
 - Use multi-package installs where available to speed up package installation
 - Use platform? and platform_family? helpers where possible to simplify the codebase

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Remove ChefSpec matchers file which is no longer necessary with ChefSpec 7.1
 - Use multi-package installs where available to speed up package installation
 - Use platform? and platform_family? helpers where possible to simplify the codebase
+- Simplify the apt_repository usage by removing `distribution` property
 - Migrate to actions
 
 ## 0.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 - Use multi-package installs where available to speed up package installation
 - Use platform? and platform_family? helpers where possible to simplify the codebase
 - Simplify the apt_repository usage by removing `distribution` property
-- Migrate to actions
+- Fix source installs on Debian 10+ and Ubuntu 18.04+
+- Migrate to Github actions for testing
 
 ## 0.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Simplify the apt_repository usage by removing `distribution` property
 - Fix source installs on Debian 10+ and Ubuntu 18.04+
 - Migrate to Github actions for testing
+- Use platform_family not platform to better support derivative OS releases like Oracle Linux
 
 ## 0.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Upgrade the default client version to 3.0.29 as 3.0.9 isn't on the Zabbix site anymore
 - Fix prebuilt installs since the packages on the Zabbix site have changed name format
 - Use the Linux 3.x prebuilt binaries not 2.6 binaries
+- Use systemd not sys-v init scripts to start the agent on Debian / RHEL based systems now
 - Use the build_essential resource and remove the dependency on the build-essential cookbook
 - Removed the apt-get update before adding the Zabbix apt repository as this is not necessary
 - Removed the include_recipe 'yum' before setting up the Zabbix yum repo as this is not necessary

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ node['zabbix']['agent']['install_method'] = 'skip'
 Version
 
 ```ruby
-node['zabbix']['agent']['version'] # Default 3.0.9
+node['zabbix']['agent']['version'] # Default 3.0.29
 ```
 
 Servers
@@ -145,7 +145,7 @@ node['zabbix']['agent']['conf']['ServerActive'] = ["Your_zabbix_active_server.co
 
 #### Package install
 
-If you do not set any attributes you will get an install of zabbix agent version 3.0.9 with
+If you do not set any attributes you will get an install of zabbix agent version 3.0.29 with
 what should be a working configuration if your DNS has aliases for zabbix.yourdomain.com and
 your hosts search yourdomain.com.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,7 +25,7 @@ else
   default['zabbix']['agent']['scripts'] = '/etc/zabbix/scripts'
 end
 
-default['zabbix']['agent']['version']           = '3.0.9'
+default['zabbix']['agent']['version']           = '3.0.29'
 default['zabbix']['agent']['servers']           = ['zabbix']
 default['zabbix']['agent']['servers_active']    = ['zabbix']
 
@@ -124,11 +124,11 @@ when 'fedora'
 end
 
 # prebuild install
-prebuild_url = 'http://www.zabbix.com/downloads/'
+prebuild_url = 'https://www.zabbix.com/downloads/'
 arch = node['kernel']['machine'] == 'x86_64' ? 'amd64' : 'i386'
-default['zabbix']['agent']['prebuild_file'] = "zabbix_agents_#{version}.linux2_6.#{arch}.tar.gz"
+default['zabbix']['agent']['prebuild_file'] = "zabbix_agent-#{version}-linux-3.0-#{arch}-static.tar.gz"
 
-default['zabbix']['agent']['prebuild_url']  = "#{prebuild_url}#{version}/zabbix_agents_#{version}.linux2_6.#{arch}.tar.gz"
+default['zabbix']['agent']['prebuild_url']  = "#{prebuild_url}#{version}/zabbix_agent-#{version}-linux-3.0-#{arch}-static.tar.gz"
 default['zabbix']['agent']['checksum'] = 'bf2ebb48fbbca66418350f399819966e'
 
 # auto-regestration

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,8 +3,7 @@
 # Attributes:: default
 
 # Directories
-default['zabbix']['etc_dir'] = case node['platform_family']
-                               when 'windows'
+default['zabbix']['etc_dir'] = if platform_family?('windows')
                                  ::File.join(ENV['PROGRAMDATA'], 'zabbix')
                                else
                                  '/etc/zabbix'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -107,11 +107,11 @@ default['zabbix']['agent']['source_url'] = "#{download_url}/#{branch}/#{version}
 default['zabbix']['agent']['tar_file'] = tar
 
 # package install
-case node['platform']
-when 'ubuntu', 'debian'
+case node['platform_family']
+when 'debian'
   default['zabbix']['agent']['package']['repo_uri'] = "http://repo.zabbix.com/zabbix/3.0/#{node['platform']}/"
   default['zabbix']['agent']['package']['repo_key'] = 'http://repo.zabbix.com/zabbix-official-repo.key'
-when 'redhat', 'centos', 'scientific', 'oracle'
+when 'rhel'
   default['zabbix']['agent']['package']['repo_uri'] = 'http://repo.zabbix.com/zabbix/3.0/rhel/$releasever/$basearch/'
   default['zabbix']['agent']['package']['repo_key'] = 'http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX'
 when 'amazon'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -135,9 +135,7 @@ default['zabbix']['agent']['checksum'] = 'bf2ebb48fbbca66418350f399819966e'
 default['zabbix']['agent']['groups'] = ['chef-agent']
 
 case node['platform_family']
-when 'rhel', 'debian'
-  default['zabbix']['agent']['init_style'] = 'sysvinit'
-when 'fedora'
+when 'fedora', 'rhel', 'debian'
   default['zabbix']['agent']['init_style'] = 'systemd'
 when 'windows'
   default['zabbix']['agent']['init_style'] = 'windows'

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -40,4 +40,4 @@ suites:
       zabbix:
         agent:
           install_method: "prebuild"
-          version: "3.0.4"
+          version: "3.0.29"

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -35,8 +35,7 @@ directory node['zabbix']['install_dir'] do
 end
 
 # Create root folders
-case node['platform_family']
-when 'windows'
+if platform_family?('windows')
   directory node['zabbix']['etc_dir'] do
     owner node['zabbix']['agent']['user'] unless node['zabbix']['agent']['user'] == 'Administrator'
     rights :read, 'Everyone', applies_to_children: true

--- a/recipes/install_package.rb
+++ b/recipes/install_package.rb
@@ -14,7 +14,6 @@ when 'windows'
 when 'debian'
   apt_repository 'zabbix' do
     uri node['zabbix']['agent']['package']['repo_uri']
-    distribution node['lsb']['codename']
     components ['main']
     key node['zabbix']['agent']['package']['repo_key']
   end

--- a/recipes/install_prebuild.rb
+++ b/recipes/install_prebuild.rb
@@ -6,8 +6,7 @@
 #
 # Apache 2.0
 #
-case node['platform']
-when 'redhat', 'centos', 'scientific', 'amazon', 'fedora'
+if platform?('redhat', 'centos', 'scientific', 'amazon', 'fedora')
   package 'redhat-lsb' do
     action :install
   end

--- a/recipes/install_prebuild.rb
+++ b/recipes/install_prebuild.rb
@@ -6,7 +6,7 @@
 #
 # Apache 2.0
 #
-if platform?('redhat', 'centos', 'scientific', 'amazon', 'fedora')
+if platform_family?('rhel', 'amazon', 'fedora')
   package 'redhat-lsb' do
     action :install
   end

--- a/recipes/install_source.rb
+++ b/recipes/install_source.rb
@@ -11,7 +11,12 @@ when 'debian'
   apt_update
 
   # install some dependencies
-  package %w(libcurl3 libcurl4-openssl-dev)
+  if (platform?('debian') && node['platform_version'].to_i >= 10) ||
+     (platform?('ubuntu') && node['platform_version'].to_i >= 18)
+    package %w(libcurl4 libcurl4-openssl-dev)
+  else
+    package %w(libcurl3 libcurl4-openssl-dev)
+  end
 
 when 'rhel', 'amazon', 'fedora'
   package %w(curl-devel openssl-devel redhat-lsb)

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'zabbix-agent::default' do
   context 'with default settings' do
     cached(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '14.04').converge(described_recipe)
+      ChefSpec::SoloRunner.new(platform: 'ubuntu').converge(described_recipe)
     end
 
     it 'includes zabbix-agent::service to insure the zabbix agent will run' do
@@ -112,7 +112,7 @@ describe 'zabbix-agent::default' do
   end
 
   context 'if installed on Ubuntu it' do
-    cached(:chef_run) { ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '14.04').converge(described_recipe) }
+    cached(:chef_run) { ChefSpec::ServerRunner.new(platform: 'ubuntu').converge(described_recipe) }
 
     it 'adds the apt repository for zabbix' do
       expect(chef_run).to add_apt_repository('zabbix').with(

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -13,14 +13,14 @@ describe 'zabbix-agent install method tests' do
       expect(chef_prebuild).to include_recipe('zabbix-agent::install_prebuild')
     end
 
-    it "gets the zabbix binary prebuild archive from 'http://www.zabbix.com/downloads/ and puts it  #{Chef::Config[:file_cache_path]}/zabbix_agents_3.0.9.linux2_6.amd64.tar.gz" do
-      expect(chef_prebuild).to create_remote_file("#{Chef::Config[:file_cache_path]}/zabbix_agents_3.0.9.linux2_6.amd64.tar.gz").with(
-        source: 'http://www.zabbix.com/downloads/3.0.9/zabbix_agents_3.0.9.linux2_6.amd64.tar.gz'
+    it "gets the zabbix binary prebuild archive from 'http://www.zabbix.com/downloads/ and puts it  #{Chef::Config[:file_cache_path]}/zabbix_agent-3.0.29-linux-3.0-amd64-static.tar.gz" do
+      expect(chef_prebuild).to create_remote_file("#{Chef::Config[:file_cache_path]}/zabbix_agent-3.0.29-linux-3.0-amd64-static.tar.gz").with(
+        source: 'https://www.zabbix.com/downloads/3.0.29/zabbix_agent-3.0.29-linux-3.0-amd64-static.tar.gz'
       )
     end
 
     it 'notifies the bash install_program when the archive is downloaded' do
-      get_file = chef_prebuild.remote_file("#{Chef::Config[:file_cache_path]}/zabbix_agents_3.0.9.linux2_6.amd64.tar.gz")
+      get_file = chef_prebuild.remote_file("#{Chef::Config[:file_cache_path]}/zabbix_agent-3.0.29-linux-3.0-amd64-static.tar.gz")
       expect(get_file).to notify('bash[install_program]').to(:run).immediately
     end
 
@@ -50,14 +50,14 @@ describe 'zabbix-agent install method tests' do
       expect(chef_source).to include_recipe('zabbix-agent::install_source')
     end
 
-    it "gets the zabbix source archive from http://downloads.sourceforge.net and puts it in #{Chef::Config[:file_cache_path]}/zabbix-3.0.9.tar.gz" do
-      expect(chef_source).to create_remote_file("#{Chef::Config[:file_cache_path]}/zabbix-3.0.9.tar.gz").with(
-        source: 'http://downloads.sourceforge.net/project/zabbix//ZABBIX%20Latest%20Stable/3.0.9/zabbix-3.0.9.tar.gz'
+    it "gets the zabbix source archive from http://downloads.sourceforge.net and puts it in #{Chef::Config[:file_cache_path]}/zabbix-3.0.29.tar.gz" do
+      expect(chef_source).to create_remote_file("#{Chef::Config[:file_cache_path]}/zabbix-3.0.29.tar.gz").with(
+        source: 'http://downloads.sourceforge.net/project/zabbix//ZABBIX%20Latest%20Stable/3.0.29/zabbix-3.0.29.tar.gz'
       )
     end
 
-    it 'the download of the zabbix source archive zabbix-3.0.9.tar.gz notifies the bash install_program' do
-      get_file = chef_source.remote_file("#{Chef::Config[:file_cache_path]}/zabbix-3.0.9.tar.gz")
+    it 'the download of the zabbix source archive zabbix-3.0.29.tar.gz notifies the bash install_program' do
+      get_file = chef_source.remote_file("#{Chef::Config[:file_cache_path]}/zabbix-3.0.29.tar.gz")
       expect(get_file).to notify('bash[install_program]').to(:run).immediately
     end
 
@@ -82,9 +82,9 @@ describe 'zabbix-agent install method tests' do
       expect(chef_source).to install_package(%w(curl-devel openssl-devel redhat-lsb))
     end
 
-    it "gets the zabbix source archive from http://downloads.sourceforge.net and puts it in #{Chef::Config[:file_cache_path]}/zabbix-3.0.9.tar.gz" do
-      expect(chef_source).to create_remote_file("#{Chef::Config[:file_cache_path]}/zabbix-3.0.9.tar.gz").with(
-        source: 'http://downloads.sourceforge.net/project/zabbix//ZABBIX%20Latest%20Stable/3.0.9/zabbix-3.0.9.tar.gz'
+    it "gets the zabbix source archive from http://downloads.sourceforge.net and puts it in #{Chef::Config[:file_cache_path]}/zabbix-3.0.29.tar.gz" do
+      expect(chef_source).to create_remote_file("#{Chef::Config[:file_cache_path]}/zabbix-3.0.29.tar.gz").with(
+        source: 'http://downloads.sourceforge.net/project/zabbix//ZABBIX%20Latest%20Stable/3.0.29/zabbix-3.0.29.tar.gz'
       )
     end
   end

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'zabbix-agent install method tests' do
   context 'with install_method=prebuild it' do
     cached(:chef_prebuild) do
-      ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '14.04') do |node|
+      ChefSpec::ServerRunner.new(platform: 'ubuntu') do |node|
         node.override['zabbix']['agent']['install_method'] = 'prebuild'
         node.override['zabbix']['agent']['init_style'] = 'sysvinit'
       end.converge('zabbix-agent::default')
@@ -40,7 +40,7 @@ describe 'zabbix-agent install method tests' do
 
   context 'with install_method=source it' do
     cached(:chef_source) do
-      ChefSpec::ServerRunner.new(platform: 'centos', version: '6.9') do |node|
+      ChefSpec::ServerRunner.new(platform: 'centos', version: '6') do |node|
         node.override['zabbix']['agent']['install_method'] = 'source'
         node.override['zabbix']['agent']['init_style'] = 'sysvinit'
       end.converge('zabbix-agent::default')
@@ -73,7 +73,7 @@ describe 'zabbix-agent install method tests' do
 
   context 'with install_method=source and on CentOS platform it' do
     cached(:chef_source) do
-      ChefSpec::ServerRunner.new(platform: 'centos', version: '6.9') do |node|
+      ChefSpec::ServerRunner.new(platform: 'centos', version: '6') do |node|
         node.override['zabbix']['agent']['install_method'] = 'source'
       end.converge('zabbix-agent::install_source')
     end
@@ -86,6 +86,54 @@ describe 'zabbix-agent install method tests' do
       expect(chef_source).to create_remote_file("#{Chef::Config[:file_cache_path]}/zabbix-3.0.9.tar.gz").with(
         source: 'http://downloads.sourceforge.net/project/zabbix//ZABBIX%20Latest%20Stable/3.0.9/zabbix-3.0.9.tar.gz'
       )
+    end
+  end
+
+  context 'with install_method=source and on Ubuntu 16.04 it' do
+    cached(:chef_source) do
+      ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04') do |node|
+        node.override['zabbix']['agent']['install_method'] = 'source'
+      end.converge('zabbix-agent::install_source')
+    end
+
+    it 'installs the packages libcurl3 and libcurl4-openssl-dev' do
+      expect(chef_source).to install_package(%w(libcurl3 libcurl4-openssl-dev))
+    end
+  end
+
+  context 'with install_method=source and on Ubuntu 18.04 it' do
+    cached(:chef_source) do
+      ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '18.04') do |node|
+        node.override['zabbix']['agent']['install_method'] = 'source'
+      end.converge('zabbix-agent::install_source')
+    end
+
+    it 'installs the packages libcurl4 and libcurl4-openssl-dev' do
+      expect(chef_source).to install_package(%w(libcurl4 libcurl4-openssl-dev))
+    end
+  end
+
+  context 'with install_method=source and on Debian 9 it' do
+    cached(:chef_source) do
+      ChefSpec::ServerRunner.new(platform: 'debian', version: '9') do |node|
+        node.override['zabbix']['agent']['install_method'] = 'source'
+      end.converge('zabbix-agent::install_source')
+    end
+
+    it 'installs the packages libcurl3 and libcurl4-openssl-dev' do
+      expect(chef_source).to install_package(%w(libcurl3 libcurl4-openssl-dev))
+    end
+  end
+
+  context 'with install_method=source and on Debian 10 it' do
+    cached(:chef_source) do
+      ChefSpec::ServerRunner.new(platform: 'debian', version: '10') do |node|
+        node.override['zabbix']['agent']['install_method'] = 'source'
+      end.converge('zabbix-agent::install_source')
+    end
+
+    it 'installs the packages libcurl4 and libcurl4-openssl-dev' do
+      expect(chef_source).to install_package(%w(libcurl4 libcurl4-openssl-dev))
     end
   end
 end


### PR DESCRIPTION
3.0.9 isn't on their site anymore so switch to 3.0.29
Fix source installs on Debian 10+ and Ubuntu 18.04+
Update the URL format for the prebuilt binaries
Switch to the Linux 3.x prebuilt binaries from the 2.6 binaries

Signed-off-by: Tim Smith <tsmith@chef.io>