### PR TITLE
fix: migrate to Policyfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ name: ci
 
 jobs:
   lint-unit:
-    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@9.0.0
     permissions:
       checks: write
       pull-requests: write
@@ -43,7 +43,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Install Chef
-        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.2
+        uses: sous-chefs/.github/.github/actions/install-workstation@9.0.0
       - name: Dokken
         uses: actionshub/test-kitchen@3.0.0
         env:

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -11,6 +11,6 @@ name: conventional-commits
 
 jobs:
   conventional-commits:
-    uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@9.0.0
     permissions:
       pull-requests: read

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Install Chef
-        uses: actionshub/chef-install@main
+        uses: sous-chefs/.github/.github/actions/install-workstation@9.0.0
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.github/workflows/prevent-file-change.yml
+++ b/.github/workflows/prevent-file-change.yml
@@ -11,7 +11,7 @@ name: prevent-file-change
 
 jobs:
   prevent-file-change:
-    uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@9.0.0
     permissions:
       pull-requests: write
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   release:
-    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@9.0.0
     secrets:
       token: ${{ secrets.PORTER_GITHUB_TOKEN }}
       supermarket_user: ${{ secrets.CHEF_SUPERMARKET_USER }}

--- a/Berksfile
+++ b/Berksfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+name 'zabbix-agent'
+
+run_list 'test::default'
+
+cookbook 'zabbix-agent', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, "test::#{recipe_name}"
+end

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -16,7 +16,7 @@ x-verifiers:
       - path: test/integration/default
 
 provisioner:
-  name: chef_infra
+  name: policyfile_zero
   product_name: chef
   product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   channel: stable
@@ -24,6 +24,7 @@ provisioner:
   multiple_converge: 2
   deprecations_as_errors: true
   chef_license: accept
+  policyfile: Policyfile.rb
 
 verifier:
   name: inspec
@@ -45,13 +46,16 @@ platforms:
 
 suites:
   - name: default
-    run_list: *default_run_list
+    provisioner:
+      named_run_list: default
     verifier: *default_verifier
 
   - name: source
-    run_list: *source_run_list
+    provisioner:
+      named_run_list: source
     verifier: *default_verifier
 
   - name: prebuild
-    run_list: *prebuild_run_list
+    provisioner:
+      named_run_list: prebuild
     verifier: *default_verifier

--- a/resources/zabbix_agent.rb
+++ b/resources/zabbix_agent.rb
@@ -174,6 +174,12 @@ action_class do
   end
 
   def install_source_method
+    if platform_family?('debian')
+      apt_update 'update package lists before source install' do
+        action :update
+      end
+    end
+
     package source_dependencies unless source_dependencies.empty?
 
     build_essential 'install build tools'

--- a/resources/zabbix_agent.rb
+++ b/resources/zabbix_agent.rb
@@ -176,7 +176,7 @@ action_class do
   def install_source_method
     if platform_family?('debian')
       apt_update 'update package lists before source install' do
-        action :update
+        action :periodic
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true

--- a/spec/unit/resources/zabbix_agent_spec.rb
+++ b/spec/unit/resources/zabbix_agent_spec.rb
@@ -83,6 +83,7 @@ describe 'zabbix_agent' do
     end
 
     it { is_expected.to install_package(%w(libcurl4 libcurl4-openssl-dev libpcre2-dev pkg-config tar)) }
+    it { is_expected.to update_apt_update('update package lists before source install') }
     it { is_expected.to install_build_essential('install build tools') }
     it { is_expected.to create_remote_file("#{Chef::Config[:file_cache_path]}/zabbix-7.0.26.tar.gz") }
     it { is_expected.to run_execute('build zabbix agent from source') }

--- a/spec/unit/resources/zabbix_agent_spec.rb
+++ b/spec/unit/resources/zabbix_agent_spec.rb
@@ -83,7 +83,7 @@ describe 'zabbix_agent' do
     end
 
     it { is_expected.to install_package(%w(libcurl4 libcurl4-openssl-dev libpcre2-dev pkg-config tar)) }
-    it { is_expected.to update_apt_update('update package lists before source install') }
+    it { is_expected.to periodic_apt_update('update package lists before source install') }
     it { is_expected.to install_build_essential('install build tools') }
     it { is_expected.to create_remote_file("#{Chef::Config[:file_cache_path]}/zabbix-7.0.26.tar.gz") }
     it { is_expected.to run_execute('build zabbix agent from source') }


### PR DESCRIPTION
## Summary
- replace Berkshelf with Policyfile dependency resolution
- switch ChefSpec to chefspec/policyfile and map Kitchen suites to named Policyfile run lists
- update sous-chefs reusable workflows/install-workstation to v9.0.0
- refresh apt metadata before Debian-family source installs to avoid stale package index failures

## Verification
- chef install Policyfile.rb
- cookstyle
- env GEM_HOME=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 /opt/chef-workstation/embedded/bin/rspec --format documentation (41 examples, 0 failures)
- yamllint .
- actionlint
- markdownlint-cli2 '**/*.md' '#CHANGELOG.md'
- git diff --check
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list
- env -u KITCHEN_LOCAL_YAML kitchen list
- env -u KITCHEN_LOCAL_YAML kitchen test default-ubuntu-2404 --destroy=always (3 controls, 10 assertions, 0 failures)

Note: Dokken could not connect to the local Docker socket in this environment, so the integration proof used the Vagrant backend.